### PR TITLE
Don't use coloring for Jython

### DIFF
--- a/src/hunter.py
+++ b/src/hunter.py
@@ -432,7 +432,7 @@ class ColorStreamAction(Action):
     @stream.setter
     def stream(self, value):
         isatty = getattr(value, 'isatty', None)
-        if isatty and isatty():
+        if isatty and isatty() and os.name != 'java':
             self._stream = AnsiToWin32(value)
             self._tty = True
             self.event_colors = EVENT_COLORS


### PR DESCRIPTION
colorama doesn't work on Jython, because there's no proper ctypes
support for Jython. ctypes is used by colorama for some Windows API calls.
The output on Jython will contain the unstripped ANSI codes, which makes it
incomprehensible.