### PR TITLE
Improve Development section in CONTRIBUTING.rst

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -37,11 +37,11 @@ Development
 
 To set up `python-hunter` for local development:
 
-1. Fork `python-hunter <https://github.com/ionelmc/python-hunter>`_
-   (look for the "Fork" button).
-2. Clone your fork locally::
+1. Fork `python-hunter <https://github.com/ionelmc/python-hunter/fork>`_.
+2. Clone your fork locally (replace ``GITUSER`` with your GitHub
+   username)::
 
-    git clone git@github.com:ionelmc/python-hunter.git
+    git clone git@github.com:GITUSER/python-hunter.git
 
 3. Create a branch for local development::
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -37,11 +37,10 @@ Development
 
 To set up `python-hunter` for local development:
 
-1. Fork `python-hunter <https://github.com/ionelmc/python-hunter/fork>`_.
-2. Clone your fork locally (replace ``GITUSER`` with your GitHub
-   username)::
+1. `Fork python-hunter <https://github.com/ionelmc/python-hunter/fork>`_.
+2. Clone your fork locally (replace ``USERNAME`` with your GitHub username)::
 
-    git clone git@github.com:GITUSER/python-hunter.git
+    git clone git@github.com:USERNAME/python-hunter.git
 
 3. Create a branch for local development::
 


### PR DESCRIPTION
This PR is not based on a specific issue. It contains two small changes for the file `CONTRIBUTING.rst`:

* Use ".../fork" at the end of URL to directly jump to the respective fork page on GitHub (makes step
  a little bit easier, both for writer and reader).
* Introduce GITUSER as replaceable, because "ionelmc" is not the fork name of the respective user.

---

Awesome project, great work Ionel! :+1: 