### PR TITLE
Try to cross-link to kwargs description

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -4,7 +4,7 @@ Configuration
 
 Default predicates and action kwargs defaults can be configured via a ``PYTHONHUNTERCONFIG`` environment variable.
 
-All the action kwargs:
+All the :ref:`actions <reference:actions>` kwargs:
 
 * ``klass``
 * ``stream``


### PR DESCRIPTION
Not sure if the syntax is correct. I am using https://docs.readthedocs.io/en/stable/guides/cross-referencing-with-sphinx.html#automatically-label-sections as a reference.