### PR TITLE
Use sys.executable everywhere in test_remote

### DIFF
--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -15,7 +15,7 @@ platform.system()
 
 @pytest.mark.skipif('platform.system() == "Windows"')
 def test_manhole():
-    with TestProcess('python', '-msamplemanhole') as target, dump_on_error(target.read):
+    with TestProcess(sys.executable, '-msamplemanhole') as target, dump_on_error(target.read):
         wait_for_strings(target.read, TIMEOUT, 'Oneshot activation is done by signal')
 
         with TestProcess('hunter-trace', '-p', str(target.proc.pid), 'stdlib=False') as tracer, dump_on_error(tracer.read):
@@ -32,7 +32,7 @@ def test_manhole():
 
 @pytest.mark.skipif('platform.system() == "Windows"')
 def test_manhole_reattach():
-    with TestProcess('python', '-msamplemanhole') as target, dump_on_error(target.read):
+    with TestProcess(sys.executable, '-msamplemanhole') as target, dump_on_error(target.read):
         wait_for_strings(target.read, TIMEOUT, 'Oneshot activation is done by signal')
 
         with TestProcess('hunter-trace', '-p', str(target.proc.pid), 'stdlib=False') as tracer, dump_on_error(tracer.read):
@@ -61,7 +61,7 @@ def test_manhole_reattach():
 
 @pytest.mark.skipif('platform.system() == "Windows"')
 def test_manhole_clean_exit():
-    with TestProcess('python', '-msamplemanhole') as target, dump_on_error(target.read):
+    with TestProcess(sys.executable, '-msamplemanhole') as target, dump_on_error(target.read):
         wait_for_strings(target.read, TIMEOUT, 'Oneshot activation is done by signal')
 
         with TestProcess('hunter-trace', '-p', str(target.proc.pid), 'stdlib=False') as tracer, dump_on_error(tracer.read):
@@ -90,7 +90,7 @@ def test_manhole_clean_exit():
 @pytest.mark.skipif('platform.python_implementation() == "PyPy"')
 @pytest.mark.skipif('not which("gdb")')
 def test_gdb():
-    with TestProcess('python', '-msamplemanhole') as target, dump_on_error(target.read):
+    with TestProcess(sys.executable, '-msamplemanhole') as target, dump_on_error(target.read):
         with TestProcess('hunter-trace', '-p', str(target.proc.pid), '--gdb', 'stdlib=False') as tracer, dump_on_error(tracer.read):
             wait_for_strings(
                 tracer.read,


### PR DESCRIPTION
Not all systems use python to run the interpreter, and this also doesn't help if the user has multiple interpreters in their path. Use sys.executable like the other test case in this file.